### PR TITLE
Fixed re-logging in bug

### DIFF
--- a/spoti-friends/src/auth/SpotifyAuth.swift
+++ b/spoti-friends/src/auth/SpotifyAuth.swift
@@ -117,6 +117,7 @@ class SpotifyAuth {
         urlComponents.path = AuthorizationConstants.AccessToken.apiTokenPath
         
         var params = AuthorizationConstants.accessTokenRequestParams
+        params["code_verifier"] = getStringFromUserDefaultsValueForKey("code_verifier")
         params["code"] = authorizationCode
         urlComponents.queryItems = params.map { URLQueryItem(name: $0.key, value: $0.value) }
         

--- a/spoti-friends/src/auth/utils/AuthorizationConstants.swift
+++ b/spoti-friends/src/auth/utils/AuthorizationConstants.swift
@@ -32,7 +32,7 @@ internal enum AuthorizationConstants {
         "grant_type": AccessToken.grantType,
         "code": "",  // will set at runtime
         "redirect_uri": redirectUri,
-        "code_verifier": getStringFromUserDefaultsValueForKey("code_verifier"),
+        "code_verifier": ""  // will set at runtime,
     ]
     
     static var refreshTokenRequestParams = [

--- a/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
+++ b/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
@@ -15,14 +15,14 @@ class AuthorizationViewModel: ObservableObject {
         // Otherwise, this is a new user.
 //        storeInUserDefaults(key: "signedInUser", value: "")
         let signedInUser = getStringFromUserDefaultsValueForKey("signedInUser")
-        if signedInUser != "" {
-            let existingUser: User = realm.objects(User.self).where { $0.spotifyId == signedInUser }.first!
-            self.user = existingUser
-            self.authorizationStatus = existingUser.authorizationStatus
-        } else {
-            self.user = User()
-            self.authorizationStatus = .unauthenticated
-        }
+//        if signedInUser != "" {
+            let existingUser: User? = realm.objects(User.self).where { $0.spotifyId == signedInUser }.first
+            self.user = existingUser ?? User()
+        self.authorizationStatus = existingUser?.authorizationStatus ?? .unauthenticated
+//        } else {
+//            self.user = User()
+//            self.authorizationStatus = .unauthenticated
+//        }
         
         self.notificationToken = realm.observe { [weak self] _, _ in
             self?.objectWillChange.send()
@@ -36,9 +36,10 @@ class AuthorizationViewModel: ObservableObject {
     
     /// Signs out the currently signed in user.
     public func signOutUser() -> Void {
+        storeInUserDefaults(key: "signedInUser", value: "")
+        storeInUserDefaults(key: "code_verifier", value: "")
         self.user = User()
         self.authorizationStatus = .unauthenticated
-        storeInUserDefaults(key: "signedInUser", value: "")
     }
     
     /// Returns the Spotify user authorization URL.

--- a/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
+++ b/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import RealmSwift
+import WebKit
 
 /// The viewmodel used for the views involving the authorization code flow.
 class AuthorizationViewModel: ObservableObject {
@@ -13,16 +14,10 @@ class AuthorizationViewModel: ObservableObject {
         
         // If we find a matching user in the database, set that as current user.
         // Otherwise, this is a new user.
-//        storeInUserDefaults(key: "signedInUser", value: "")
         let signedInUser = getStringFromUserDefaultsValueForKey("signedInUser")
-//        if signedInUser != "" {
-            let existingUser: User? = realm.objects(User.self).where { $0.spotifyId == signedInUser }.first
-            self.user = existingUser ?? User()
+        let existingUser: User? = realm.objects(User.self).where { $0.spotifyId == signedInUser }.first
+        self.user = existingUser ?? User()
         self.authorizationStatus = existingUser?.authorizationStatus ?? .unauthenticated
-//        } else {
-//            self.user = User()
-//            self.authorizationStatus = .unauthenticated
-//        }
         
         self.notificationToken = realm.observe { [weak self] _, _ in
             self?.objectWillChange.send()
@@ -36,6 +31,14 @@ class AuthorizationViewModel: ObservableObject {
     
     /// Signs out the currently signed in user.
     public func signOutUser() -> Void {
+        // Clear cookies of Spotify sign in WebKit View (so it forgets previous user's)
+        let dataStore = WKWebsiteDataStore.default()
+        dataStore.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
+            records.forEach { record in
+                dataStore.removeData(ofTypes: record.dataTypes, for: [record], completionHandler: {})
+            }
+        }
+        
         storeInUserDefaults(key: "signedInUser", value: "")
         storeInUserDefaults(key: "code_verifier", value: "")
         self.user = User()


### PR DESCRIPTION
#### Changes
- Fixed re-logging in bug
  - It was being caused because we were passing in an incorrect `code_verifier` value
  - We were setting the `code_verifier` value at compile time (since it was in a static enum). Changed it to be set at runtime.
- Also cleared Spotify sign in WebKit View cookies so it forgets the user after logging out