### PR TITLE
Fix duplicate spotify profiles bug

### DIFF
--- a/spoti-friends/src/auth/SpotifyAuth.swift
+++ b/spoti-friends/src/auth/SpotifyAuth.swift
@@ -24,7 +24,7 @@ class SpotifyAuth {
     }
     
     /// Handles the response from the Spotify authorization flow depending on whether the user granted authorization or denied authorization.
-    func handleResponseUrl(user: User, url: URL, authorizationStatus: inout AuthorizationStatus) async -> Void {
+    @MainActor func handleResponseUrl(user: User, url: URL, authorizationStatus: inout AuthorizationStatus) async -> AuthorizationStatus {
         do {
             guard let responseUrlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
                   let queryItems = responseUrlComponents.queryItems
@@ -36,22 +36,26 @@ class SpotifyAuth {
             
             if (await userExistsInDatabase(user)) {
                 storeSignedInUser(user)
-                authorizationStatus = .granted
+//                authorizationStatus = .granted
+                return .granted
             } else {
                 if (userGrantedAuthorization(queryItems)) {
                     user.setAuthorizationStatusAs(.granted)
                     await user.spotifyProfile?.storeProfilePictureLocally()
                     storeSignedInUser(user)
                     await RealmDatabase.shared.addToRealm(object: user);
-                    authorizationStatus = .granted
+//                    authorizationStatus = .granted
+                    return .granted
                 }
                 else {
                     // Handle authorization denied flow
-                    authorizationStatus = .denied
+//                    authorizationStatus = .denied
+                    return .denied
                 }
             }
         } catch {
             printError("\(error)")
+            return .unauthenticated
         }
     }
     
@@ -68,7 +72,11 @@ class SpotifyAuth {
                                                                                    endpoint: .getCurrentUsersProfile,
                                                                                    responseType: SpotifyProfile.self,
                                                                                    accessToken: spotifyWebAccessToken?.access_token ?? "")
-            user.setSpotifyProfile(spotifyProfile)
+        
+            let realm = try! await Realm()
+            // Check if the user's SpotifyProfile already exists in Realm
+            let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: spotifyProfile.spotifyId)
+            user.setSpotifyProfile(existingProfile ?? spotifyProfile)
             user.setSpotifyId(spotifyProfile.spotifyId)
             
             let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
@@ -76,20 +84,18 @@ class SpotifyAuth {
             
             let friends = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: internalAPIAccessToken.accessToken)
             
-            let realm = try! await Realm()
-            
             for friend in friends {
-                // Check if the friend's SpotifyProfile already exists in Realm
-                if let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId) {
-                    // Associate the existing profile with the user
-                    user.friends.append(existingProfile)
-                } else {
-                    // If not, add the new profile to the user's friends list
-                    user.friends.append(friend)
-                }
-            }
-            
-            //            user.setFriends(friends)
+                        if let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId) {
+                            // Associate the existing profile with the user
+                            user.friends.append(existingProfile)
+                        } else {
+                            // Add the new profile to both the user's friends list and the Realm
+                            user.friends.append(friend)
+                            try realm.write {
+                                realm.add(friend)
+                            }
+                        }
+                    }
         } catch {
             printError("\(error)")
         }

--- a/spoti-friends/src/auth/SpotifyAuth.swift
+++ b/spoti-friends/src/auth/SpotifyAuth.swift
@@ -24,7 +24,7 @@ class SpotifyAuth {
     }
     
     /// Handles the response from the Spotify authorization flow depending on whether the user granted authorization or denied authorization.
-    @MainActor func handleResponseUrl(user: User, url: URL, authorizationStatus: inout AuthorizationStatus) async -> AuthorizationStatus {
+    @MainActor func handleResponseUrl(user: User, url: URL) async -> AuthorizationStatus {
         do {
             guard let responseUrlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
                   let queryItems = responseUrlComponents.queryItems
@@ -36,7 +36,6 @@ class SpotifyAuth {
             
             if (await userExistsInDatabase(user)) {
                 storeSignedInUser(user)
-//                authorizationStatus = .granted
                 return .granted
             } else {
                 if (userGrantedAuthorization(queryItems)) {
@@ -44,14 +43,9 @@ class SpotifyAuth {
                     await user.spotifyProfile?.storeProfilePictureLocally()
                     storeSignedInUser(user)
                     await RealmDatabase.shared.addToRealm(object: user);
-//                    authorizationStatus = .granted
                     return .granted
                 }
-                else {
-                    // Handle authorization denied flow
-//                    authorizationStatus = .denied
-                    return .denied
-                }
+                return .denied
             }
         } catch {
             printError("\(error)")
@@ -68,34 +62,31 @@ class SpotifyAuth {
             let spotifyWebAccessToken = try await requestAccessTokenObject(authorizationCode: authorizationCode)
             user.setSpotifyWebAccessToken(spotifyWebAccessToken!)
             
+            let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
+            user.setInternalAPIAccessToken(internalAPIAccessToken)
+            
             let spotifyProfile: SpotifyProfile = try await SpotifyAPI.shared.fetch(method: .GET,
                                                                                    endpoint: .getCurrentUsersProfile,
                                                                                    responseType: SpotifyProfile.self,
                                                                                    accessToken: spotifyWebAccessToken?.access_token ?? "")
-        
+            
             let realm = try! await Realm()
-            // Check if the user's SpotifyProfile already exists in Realm
+            
+            // A new user may already have a SpotifyProfile in the database, if an existing user has them as a friend.
+            // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
             let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: spotifyProfile.spotifyId)
             user.setSpotifyProfile(existingProfile ?? spotifyProfile)
             user.setSpotifyId(spotifyProfile.spotifyId)
             
-            let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
-            user.setInternalAPIAccessToken(internalAPIAccessToken)
-            
+            // Same as above.
+            // The friend of a new user may already have a SpotifyProfile in the database, if an existing user is also friends with them.
+            // If so, use the existing profile to avoid creating another SpotifyProfile with a duplicate primary key.
             let friends = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: internalAPIAccessToken.accessToken)
-            
             for friend in friends {
-                        if let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId) {
-                            // Associate the existing profile with the user
-                            user.friends.append(existingProfile)
-                        } else {
-                            // Add the new profile to both the user's friends list and the Realm
-                            user.friends.append(friend)
-                            try realm.write {
-                                realm.add(friend)
-                            }
-                        }
-                    }
+                let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId)
+                user.friends.append(existingProfile ?? friend)
+                if existingProfile == nil { await RealmDatabase.shared.addToRealm(object: friend); }
+            }
         } catch {
             printError("\(error)")
         }

--- a/spoti-friends/src/auth/SpotifyAuth.swift
+++ b/spoti-friends/src/auth/SpotifyAuth.swift
@@ -56,16 +56,13 @@ class SpotifyAuth {
     }
     
     /// Populates the `user` fields with their data.
-    private func populateUserWithData(_ user: User, queryItems: [URLQueryItem]) async -> Void {
+    @MainActor private func populateUserWithData(_ user: User, queryItems: [URLQueryItem]) async -> Void {
         do {
             let authorizationCode = try getAuthorizationCodeFromQueryItems(queryItems)
             user.setAuthorizationCode(authorizationCode)
             
             let spotifyWebAccessToken = try await requestAccessTokenObject(authorizationCode: authorizationCode)
             user.setSpotifyWebAccessToken(spotifyWebAccessToken!)
-            
-            let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
-            user.setInternalAPIAccessToken(internalAPIAccessToken)
             
             let spotifyProfile: SpotifyProfile = try await SpotifyAPI.shared.fetch(method: .GET,
                                                                                    endpoint: .getCurrentUsersProfile,
@@ -74,8 +71,25 @@ class SpotifyAuth {
             user.setSpotifyProfile(spotifyProfile)
             user.setSpotifyId(spotifyProfile.spotifyId)
             
+            let internalAPIAccessToken = try await fetchInternalAPIAccessToken(spDcCookieValue: user.spDcCookie!.value, existingToken: user.internalAPIAccessToken)
+            user.setInternalAPIAccessToken(internalAPIAccessToken)
+            
             let friends = try await SpotifyAPI.shared.getListOfUsersFriends(internalAPIAccessToken: internalAPIAccessToken.accessToken)
-            user.setFriends(friends)
+            
+            let realm = try! await Realm()
+            
+            for friend in friends {
+                // Check if the friend's SpotifyProfile already exists in Realm
+                if let existingProfile = realm.object(ofType: SpotifyProfile.self, forPrimaryKey: friend.spotifyId) {
+                    // Associate the existing profile with the user
+                    user.friends.append(existingProfile)
+                } else {
+                    // If not, add the new profile to the user's friends list
+                    user.friends.append(friend)
+                }
+            }
+            
+            //            user.setFriends(friends)
         } catch {
             printError("\(error)")
         }

--- a/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
+++ b/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
@@ -53,7 +53,7 @@ class AuthorizationViewModel: ObservableObject {
     /// Handler for when the user has completed the Spotify authorization process and is redirected back to the app.
     public func handleRedirectBackToApp(_ responseUrl: URL) -> Void {
         Task {
-            await SpotifyAuth.shared.handleResponseUrl(user: self.user, url: responseUrl, authorizationStatus: &self.authorizationStatus)
+            self.authorizationStatus = await SpotifyAuth.shared.handleResponseUrl(user: self.user, url: responseUrl, authorizationStatus: &self.authorizationStatus)
         }
     }
     

--- a/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
+++ b/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
@@ -15,20 +15,9 @@ class AuthorizationViewModel: ObservableObject {
         // If we find a matching user in the database, set that as current user.
         // Otherwise, this is a new user.
         let signedInUser = getStringFromUserDefaultsValueForKey("signedInUser")
-<<<<<<< HEAD
-//        if signedInUser != "" {
-            let existingUser: User? = realm.objects(User.self).where { $0.spotifyId == signedInUser }.first
-            self.user = existingUser ?? User()
-        self.authorizationStatus = existingUser?.authorizationStatus ?? .unauthenticated
-//        } else {
-//            self.user = User()
-//            self.authorizationStatus = .unauthenticated
-//        }
-=======
         let existingUser: User? = realm.objects(User.self).where { $0.spotifyId == signedInUser }.first
         self.user = existingUser ?? User()
         self.authorizationStatus = existingUser?.authorizationStatus ?? .unauthenticated
->>>>>>> origin
         
         self.notificationToken = realm.observe { [weak self] _, _ in
             self?.objectWillChange.send()

--- a/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
+++ b/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
@@ -53,7 +53,7 @@ class AuthorizationViewModel: ObservableObject {
     /// Handler for when the user has completed the Spotify authorization process and is redirected back to the app.
     public func handleRedirectBackToApp(_ responseUrl: URL) -> Void {
         Task {
-            self.authorizationStatus = await SpotifyAuth.shared.handleResponseUrl(user: self.user, url: responseUrl, authorizationStatus: &self.authorizationStatus)
+            self.authorizationStatus = await SpotifyAuth.shared.handleResponseUrl(user: self.user, url: responseUrl)
         }
     }
     

--- a/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
+++ b/spoti-friends/src/auth/viewModels/AuthorizationViewModel.swift
@@ -15,14 +15,14 @@ class AuthorizationViewModel: ObservableObject {
         // Otherwise, this is a new user.
 //        storeInUserDefaults(key: "signedInUser", value: "")
         let signedInUser = getStringFromUserDefaultsValueForKey("signedInUser")
-        if signedInUser != "" {
-            let existingUser: User = realm.objects(User.self).where { $0.spotifyId == signedInUser }.first!
-            self.user = existingUser
-            self.authorizationStatus = existingUser.authorizationStatus
-        } else {
-            self.user = User()
-            self.authorizationStatus = .unauthenticated
-        }
+//        if signedInUser != "" {
+            let existingUser: User? = realm.objects(User.self).where { $0.spotifyId == signedInUser }.first
+            self.user = existingUser ?? User()
+        self.authorizationStatus = existingUser?.authorizationStatus ?? .unauthenticated
+//        } else {
+//            self.user = User()
+//            self.authorizationStatus = .unauthenticated
+//        }
         
         self.notificationToken = realm.observe { [weak self] _, _ in
             self?.objectWillChange.send()
@@ -36,9 +36,10 @@ class AuthorizationViewModel: ObservableObject {
     
     /// Signs out the currently signed in user.
     public func signOutUser() -> Void {
+        storeInUserDefaults(key: "signedInUser", value: "")
+        storeInUserDefaults(key: "code_verifier", value: "")
         self.user = User()
         self.authorizationStatus = .unauthenticated
-        storeInUserDefaults(key: "signedInUser", value: "")
     }
     
     /// Returns the Spotify user authorization URL.

--- a/spoti-friends/src/common/views/AuthenticatedView.swift
+++ b/spoti-friends/src/common/views/AuthenticatedView.swift
@@ -2,10 +2,12 @@ import SwiftUI
 
 /// The view for when a user is signed into the app.
 struct AuthenticatedView: View {
-    @EnvironmentObject var friendActivityViewModel: FriendActivityViewModel
+    @StateObject var friendActivityViewModel: FriendActivityViewModel
     @EnvironmentObject var authorizationViewModel: AuthorizationViewModel
     
     init() {
+        _friendActivityViewModel = StateObject(wrappedValue: FriendActivityViewModel(user: AuthorizationViewModel().user, friendActivites: []))
+        
         let standardAppearance = UITabBarAppearance()
         standardAppearance.backgroundColor = UIColor(Color.PresetColour.darkgrey)
         UITabBar.appearance().standardAppearance = standardAppearance
@@ -25,8 +27,12 @@ struct AuthenticatedView: View {
                 Label("My Profile", systemImage: "person")
             }
             .environmentObject(authorizationViewModel)
+            .environmentObject(friendActivityViewModel)
         }
         .tint(Color.PresetColour.spotifyGreen)
+        .onAppear {
+            friendActivityViewModel.user = authorizationViewModel.user
+        }
     }
 }
 

--- a/spoti-friends/src/common/views/RootView.swift
+++ b/spoti-friends/src/common/views/RootView.swift
@@ -10,7 +10,6 @@ import RealmSwift
 /// If the user has not completed authorization, render the `SignInView`.
 struct RootView: View {
     @EnvironmentObject private var authorizationViewModel: AuthorizationViewModel
-//    @StateObject private var friendActivityViewModel: FriendActivityViewModel
     @State private var authorizationStatus: AuthorizationStatus = .unauthenticated
     
     var body: some View {

--- a/spoti-friends/src/common/views/RootView.swift
+++ b/spoti-friends/src/common/views/RootView.swift
@@ -10,12 +10,8 @@ import RealmSwift
 /// If the user has not completed authorization, render the `SignInView`.
 struct RootView: View {
     @EnvironmentObject private var authorizationViewModel: AuthorizationViewModel
-    @StateObject private var friendActivityViewModel: FriendActivityViewModel
+//    @StateObject private var friendActivityViewModel: FriendActivityViewModel
     @State private var authorizationStatus: AuthorizationStatus = .unauthenticated
-    
-    init() {
-        _friendActivityViewModel = StateObject(wrappedValue: FriendActivityViewModel(user: AuthorizationViewModel().user, friendActivites: []))
-    }
     
     var body: some View {
         // Navigate to the appropriate view depending on the user's authorization status
@@ -25,7 +21,6 @@ struct RootView: View {
                 UnauthenticatedView()
             case .granted:
                 AuthenticatedView()
-                    .environmentObject(friendActivityViewModel)
                     .environmentObject(authorizationViewModel)
             case .denied:
                 AuthorizationDeniedView()
@@ -36,9 +31,6 @@ struct RootView: View {
         .onReceive(authorizationViewModel.$authorizationStatus, perform: { _ in
             self.authorizationStatus = self.authorizationViewModel.authorizationStatus
         })
-        .onAppear {
-            friendActivityViewModel.user = authorizationViewModel.user
-        }
     }
 }
 

--- a/spoti-friends/src/spotify/models/SpotifyProfile/SpotifyProfile.swift
+++ b/spoti-friends/src/spotify/models/SpotifyProfile/SpotifyProfile.swift
@@ -40,6 +40,14 @@ class SpotifyProfile: Object, Decodable {
         case image = "images"
     }
     
+    @MainActor public func getSpotifyId() -> String {
+        return self.spotifyId
+    }
+    
+    @MainActor public func getImage() -> String {
+        return self.image
+    }
+    
     public func getSpotifyIdFromUri(spotifyUri: String) -> String {
         return spotifyUri.components(separatedBy: ":").last ?? ""
     }
@@ -56,8 +64,8 @@ class SpotifyProfile: Object, Decodable {
     /// Stores the profile picture on disk using the Spotify ID as the image name.
     public func storeProfilePictureLocally() async -> Void {
         do {
-            let imageName = self.spotifyId
-            let link = self.image
+            let imageName = await self.getSpotifyId()
+            let link = await self.getImage()
             
             // Return early if the user does not have a profile picture
             if link == "" { return }


### PR DESCRIPTION
#### Changes
- Fixed the bug where we were attempting to create duplicate Spotify Profiles. Instead, only friends who are not in the database already get added; otherwise, link the existing profile as a friend.
- Also, handled the case where a new user already had a`SpotifyProfile` in the database, since they were a friend of an existing user.
- Fixed a bug where a user would log out, then a new user would log in but would see the previous user's friend activity.
