### PR TITLE
Display users recent songs

### DIFF
--- a/spoti-friends/src/profile/viewModels/ProfileViewModel.swift
+++ b/spoti-friends/src/profile/viewModels/ProfileViewModel.swift
@@ -39,6 +39,31 @@ class ProfileViewModel: ObservableObject {
         return -1
     }
     
+    /// Fetches and returns the current user's recent tracks.
+    ///
+    /// - Parameters:
+    ///   - limit: The maximum number of items to return. Default: 5. Minimum: 1. Maximum: 50.
+    @MainActor func getCurrentUsersRecentTracks(limit: Int)
+    async -> TracksWithResponseMetadata? {
+        do {
+            let accessToken = try await self.user.getSpotifyWebAccessToken().access_token
+            let queryParams = [
+                URLQueryItem(name: "limit", value: String(limit))
+            ]
+            let response = try await SpotifyAPI.shared.fetch(method: .GET,
+                                                             endpoint: .getCurrentUsersRecentTracks,
+                                                             responseType: GetCurrentUserRecentTracksResponse.self,
+                                                             accessToken: accessToken,
+                                                             queryParams: queryParams)
+            
+            return TracksWithResponseMetadata(tracks: response.extractTracksFromItems(), isEmpty: response.items.isEmpty)
+        }
+        catch {
+            printError("\(error)")
+            return nil
+        }
+    }
+    
     /// Fetches and returns the current user's top tracks.
     ///
     /// - Parameters:
@@ -108,6 +133,23 @@ extension ProfileViewModel {
     
     private struct GetCurrentUserPlayistsResponse: Decodable {
         let total: Int
+    }
+    
+    private struct GetCurrentUserRecentTracksResponse: Decodable {
+        let items: [Items]
+        
+        struct Items: Decodable {
+            let track: Track
+        }
+        
+        /// Combines all nested `track` objects within `items` and returns it as an array.
+        func extractTracksFromItems() -> [Track] {
+            var tracks: [Track] = []
+            items.forEach { item in
+                tracks.append(item.track)
+            }
+            return tracks
+        }
     }
     
     public class GetCurrentUserTopTracksResponse: Decodable {

--- a/spoti-friends/src/profile/views/ArtistList.swift
+++ b/spoti-friends/src/profile/views/ArtistList.swift
@@ -31,7 +31,7 @@ struct ArtistList: View {
                                 
                                 // Artist genres
                                 HStack(spacing: 0) {
-                                    let genres = Array(artist.genres.prefix(3)) // Convert List<String> to [String]
+                                    let genres = Array(artist.genres.prefix(2)) // Convert List<String> to [String]
                                     ForEach(genres.indices, id: \.self) { index in
                                         let genre = genres[index]
                                         
@@ -42,6 +42,7 @@ struct ArtistList: View {
                                         .foregroundStyle(Color.PresetColour.whiteSecondary)
                                     }
                                 }
+                                .lineLimit(1)
                             }
                             
                             Spacer() // To left align the content

--- a/spoti-friends/src/profile/views/ProfileDetails.swift
+++ b/spoti-friends/src/profile/views/ProfileDetails.swift
@@ -59,8 +59,8 @@ struct ProfileDetails: View {
                     fetchedDetails = false
                     Task {
                         // NOTE: Comment out these two lines to fix SwiftUI Previews
-                        followerCount = await profileViewModel.getCurrentUsersFollowerCount()
-                        playlistCount = await profileViewModel.getCurrentUsersPlaylistCount()
+//                        followerCount = await profileViewModel.getCurrentUsersFollowerCount()
+//                        playlistCount = await profileViewModel.getCurrentUsersPlaylistCount()
                         fetchedDetails = true
                     }
                 }

--- a/spoti-friends/src/profile/views/ProfileDetails.swift
+++ b/spoti-friends/src/profile/views/ProfileDetails.swift
@@ -59,8 +59,8 @@ struct ProfileDetails: View {
                     fetchedDetails = false
                     Task {
                         // NOTE: Comment out these two lines to fix SwiftUI Previews
-//                        followerCount = await profileViewModel.getCurrentUsersFollowerCount()
-//                        playlistCount = await profileViewModel.getCurrentUsersPlaylistCount()
+                        followerCount = await profileViewModel.getCurrentUsersFollowerCount()
+                        playlistCount = await profileViewModel.getCurrentUsersPlaylistCount()
                         fetchedDetails = true
                     }
                 }

--- a/spoti-friends/src/profile/views/ProfileView.swift
+++ b/spoti-friends/src/profile/views/ProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// - Returns: A view for the user's Spotify Profile.
 struct ProfileView: View {
     let profile: SpotifyProfile
+    @State private var recentTracks: ProfileViewModel.TracksWithResponseMetadata
     @State private var topTracks: ProfileViewModel.TracksWithResponseMetadata
     @State private var topArtists: ProfileViewModel.ArtistsWithResponseMetadata
     @StateObject private var profileViewModel: ProfileViewModel
@@ -17,9 +18,10 @@ struct ProfileView: View {
     
     /// NOTE: `topTracks` and `topArtists` default to `[]` so that we don't need to pass them in from `AuthenticatedView`.
     /// However, we do want to pass in mock data for previews, so that's why we want them as optional parameters.
-    init(profile: SpotifyProfile, topTracks: [Track] = [], topArtists: [Artist] = []) {
+    init(profile: SpotifyProfile, recentTracks: [Track] = [], topTracks: [Track] = [], topArtists: [Artist] = []) {
         self.profile = profile
         _profileViewModel = StateObject(wrappedValue: ProfileViewModel(user: AuthorizationViewModel().user))
+        self.recentTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: recentTracks)
         self.topTracks = ProfileViewModel.TracksWithResponseMetadata(tracks: topTracks)
         self.topArtists = ProfileViewModel.ArtistsWithResponseMetadata(artists: topArtists)
     }
@@ -33,6 +35,23 @@ struct ProfileView: View {
                         .environmentObject(profileViewModel)
                         .environmentObject(friendActivityViewModel)
                     
+                    // Recent Tracks
+                    VStack (alignment: .leading) {
+                        Text("Recent Songs")
+                            .font(.body)
+                            .foregroundStyle(Color.PresetColour.whitePrimary)
+                        
+                        if (recentTracks.isEmpty) {
+                            Text("It's oddly quiet here...")
+                                .font(.callout)
+                                .foregroundStyle(Color.PresetColour.whiteSecondary)
+                                .padding(.vertical, 4)
+                        }
+                        else {
+                            TrackList(tracks: recentTracks.tracks)
+                        }
+                    }
+                    
                     // Top Tracks
                     VStack (alignment: .leading) {
                         Text("Top Songs")
@@ -45,7 +64,7 @@ struct ProfileView: View {
                         if (topTracks.isEmpty) {
                             Text("Not enough listening data this month.")
                                 .font(.callout)
-                                .foregroundStyle(Color.PresetColour.whitePrimary)
+                                .foregroundStyle(Color.PresetColour.whiteSecondary)
                                 .padding(.vertical, 4)
                         }
                         else {
@@ -65,7 +84,7 @@ struct ProfileView: View {
                         if (topArtists.isEmpty) {
                             Text("Not enough listening data this month.")
                                 .font(.callout)
-                                .foregroundStyle(Color.PresetColour.whitePrimary)
+                                .foregroundStyle(Color.PresetColour.whiteSecondary)
                                 .padding(.vertical, 4)
                         }
                         else {
@@ -89,6 +108,9 @@ struct ProfileView: View {
                 
                 Task {
                     // NOTE: Comment out these lines to fix SwiftUI Previews
+                    recentTracks = await profileViewModel.getCurrentUsersRecentTracks(limit: 5)
+                    ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
+                    
                     topTracks = await profileViewModel.getCurrentUsersTopTracks(timeRange: .oneMonth, limit: 5)
                     ?? ProfileViewModel.TracksWithResponseMetadata(tracks: [])
                     
@@ -122,10 +144,11 @@ struct ProfileView: View {
 #Preview {
     ZStack {
         let user = UserMock.userJimHalpert
+        let recentTracks = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor]
         let topTracks = [TrackMock.iRememberEverything, TrackMock.luxury, TrackMock.traitor]
         let topArtists = [ArtistMock.zachBryan, ArtistMock.jonBellion, ArtistMock.oliviaRodrigo, ArtistMock.kaceyMusgraves]
         
-        ProfileView(profile: user.spotifyProfile!, topTracks: topTracks, topArtists: topArtists)
+        ProfileView(profile: user.spotifyProfile!, recentTracks: recentTracks, topTracks: topTracks, topArtists: topArtists)
             .environmentObject(AuthorizationViewModel())
             .environmentObject(FriendActivityViewModel(user: user, friendActivites: []))
     }

--- a/spoti-friends/src/profile/views/ProfileView.swift
+++ b/spoti-friends/src/profile/views/ProfileView.swift
@@ -4,7 +4,9 @@ import SwiftUI
 ///
 /// - Parameters:
 ///   - profile: The Spotify profile to display.
+///   - recentTracks: A list of the profile's recently played tracks.
 ///   - topTracks: A list of the profile's top tracks over the last month.
+///   - topArtists: A list of the profile's top artists over the last month.
 ///
 /// - Returns: A view for the user's Spotify Profile.
 struct ProfileView: View {

--- a/spoti-friends/src/spotify/spotifyAPI/utils/Constants.swift
+++ b/spoti-friends/src/spotify/spotifyAPI/utils/Constants.swift
@@ -11,6 +11,7 @@ internal enum APIConstants {
 internal enum APIEndpoint: String {
     case getCurrentUsersProfile = "/me"
     case getCurrentUsersPlaylists = "/me/playlists"
+    case getCurrentUsersRecentTracks = "/me/player/recently-played"
     case getCurrentUsersTopTracks = "/me/top/tracks"
     case getCurrentUsersTopArtists = "/me/top/artists"
 }


### PR DESCRIPTION
#### Changes
- Added API endpoint to fetch the current user's recently played songs
- Displayed the top 5 recent songs in the Profile View
- Decreased max genres displayed for an artist from 3 to 2